### PR TITLE
Fix configure()

### DIFF
--- a/sopel_modules/youtube/youtube.py
+++ b/sopel_modules/youtube/youtube.py
@@ -18,8 +18,8 @@ class YoutubeSection(StaticSection):
 
 
 def configure(config):
-    config.define_section('youtube', YoutubeSection)
-    config.bugzilla.configure_setting(
+    config.define_section('youtube', YoutubeSection, validate=False)
+    config.youtube.configure_setting(
         'api_key',
         'Enter your Google API key.',
     )


### PR DESCRIPTION
Don't validate `[youtube]` section in `configure()` as it will fail immediately unless `api_key` has been added to the config already.
