### PR TITLE
Fix reference to youtube section during configure

### DIFF
--- a/sopel_modules/youtube/youtube.py
+++ b/sopel_modules/youtube/youtube.py
@@ -19,7 +19,7 @@ class YoutubeSection(StaticSection):
 
 def configure(config):
     config.define_section('youtube', YoutubeSection)
-    config.bugzilla.configure_setting(
+    config.youtube.configure_setting(
         'api_key',
         'Enter your Google API key.',
     )


### PR DESCRIPTION
Incorrectly references config.bugzilla, most likely from unchecked copy-paste
