### PR TITLE
Fix error when comments are disabled

### DIFF
--- a/sopel_modules/youtube/youtube.py
+++ b/sopel_modules/youtube/youtube.py
@@ -95,7 +95,7 @@ def _say_result(bot, trigger, id_, include_link=True):
     message = (
         '[You' + color('Tube', colors.WHITE, colors.RED)  + '] '
         '{title} | Uploader: {uploader} | Uploaded: {uploaded} | '
-        'Length: {length} | Views: {views:,} | Comments: {comments:,}'
+        'Length: {length} | Views: {views:,} | Comments: {comments}'
     )
 
     snippet = result['snippet']
@@ -103,6 +103,9 @@ def _say_result(bot, trigger, id_, include_link=True):
     statistics = result['statistics']
     duration = _parse_duration(details['duration'])
     uploaded = _parse_published_at(bot, trigger, snippet['publishedAt'])
+    comments = statistics.get('commentCount', '-')
+    if comments != '-':
+        comments = '{:,}'.format(int(comments))
 
     message = message.format(
         title=snippet['title'],
@@ -110,7 +113,7 @@ def _say_result(bot, trigger, id_, include_link=True):
         length=duration,
         uploaded=uploaded,
         views=int(statistics['viewCount']),
-        comments=int(statistics['commentCount']),
+        comments=comments,
     )
     if 'likeCount' in statistics:
         likes = int(statistics['likeCount'])


### PR DESCRIPTION
Old:

```
<@maxpowa> https://www.youtube.com/watch?v=eybEd_ZQcvI  
<Iori> [irc.py] Exception from #Inumuta: TypeError: get() takes no keyword arguments (file "/home/iori/Snakepit/lib/python3.4/site-packages/sopel_modules/youtube/youtube.py", line 106, in _say_result) (:maxpowa!m@xpw.us PRIVMSG #Inumuta :https://www.youtube.com/watch?v=eybEd_ZQcvI)
```

Fixed:

```
<@maxpowa> https://www.youtube.com/watch?v=eybEd_ZQcvI  
<Iori> [YouTube] 2016年1月新番組「だがしかし」第2弾PV【TBS】 | Uploader: TBS animation | Uploaded: 2015-12-29 - 02:43:05 | Length: 1m 1s | Views: 201,700 | Comments: -
```

Just uses `-` when comments are disabled on the video.
