### PR TITLE
Add retry

### DIFF
--- a/sopel_modules/youtube/youtube.py
+++ b/sopel_modules/youtube/youtube.py
@@ -73,6 +73,10 @@ def search(bot, trigger):
                 maxResults=1,
             ).execute()
         except ConnectionError:
+            if n >= num_retries:
+                bot.say('Maximum retries exceeded while searching YouTube for '
+                        '"{}", please try again later.'.format(trigger.group(2)))
+                return
             sleep(random() * 2**n)
             continue
         break
@@ -101,6 +105,10 @@ def _say_result(bot, trigger, id_, include_link=True):
                 part='snippet,contentDetails,statistics',
             ).execute().get('items')
         except ConnectionError:
+            if n >= num_retries:
+                bot.say('Maximum retries exceeded fetching YouTube video {},'
+                        ' please try again later.'.format(id_))
+                return
             sleep(random() * 2**n)
             continue
         break


### PR DESCRIPTION
Because we can only use an older version of Google's python API bindings, you do not get retries builtin. This makes YT lookups unreliable. This PR catches `ConnectionError`, sleeps with an exponential backoff and tries again.