### PR TITLE
Avoid errors during reload

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sopel>=6.0,<7
 google-api-python-client>=1.5.5,<1.6
+oauth2client<4.0.0


### PR DESCRIPTION
`WARNING:googleapiclient.discovery_cache:file_cache is unavailable when using oauth2client >= 4.0.0`