### PR TITLE
Allow importing to fail so setup.py can get the version

### DIFF
--- a/sopel_modules/youtube/__init__.py
+++ b/sopel_modules/youtube/__init__.py
@@ -5,7 +5,12 @@ YouTube module for Sopel
 """
 from __future__ import unicode_literals, absolute_import, division, print_function
 
-from .youtube import *
+try:
+    from .youtube import *
+except ImportError:
+    # probably being imported by setup.py to get metadata before installation
+    # no cause for alarm
+    pass
 
 __author__ = 'E. Powell'
 __email__ = 'powell.518@gmail.com'


### PR DESCRIPTION
Short of jumping through some annoying hoops to restructure the package, this is the simplest solution.

Sopel modules can't be run from source directly, as Sopel itself can be, so this shouldn't cause a lot of confusion.

Resolves #9.