### PR TITLE
youtube: updating deprecated contains call

### DIFF
--- a/sopel_modules/youtube/youtube.py
+++ b/sopel_modules/youtube/youtube.py
@@ -42,7 +42,7 @@ def configure(config):
 
 def setup(bot):
     bot.config.define_section('youtube', YoutubeSection)
-    if not bot.memory.contains('url_callbacks'):
+    if 'url_callbacks' not in bot.memory:
         bot.memory['url_callbacks'] = tools.SopelMemory()
     bot.memory['url_callbacks'][regex] = get_info
     global API


### PR DESCRIPTION
Cherry-picked an old state of #15 (by @RustyBower) to eliminate deprecation warnings in a way compatible with Sopel 6.x instances, so users aren't stuck with those in the months before Sopel 7 drops.