### PR TITLE
Work around Google/YouTube bad timestamp data

### DIFF
--- a/sopel_modules/youtube/youtube.py
+++ b/sopel_modules/youtube/youtube.py
@@ -165,6 +165,9 @@ def _parse_duration(duration):
 
 
 def _parse_published_at(bot, trigger, published):
-    pubdate = datetime.datetime.strptime(published, '%Y-%m-%dT%H:%M:%S.%fZ')
+    try:
+        pubdate = datetime.datetime.strptime(published, '%Y-%m-%dT%H:%M:%S.%fZ')
+    except ValueError:
+        pubdate = datetime.datetime.strptime(published, '%Y-%m-%dT%H:%M:%SZ')
     return tools.time.format_time(bot.db, bot.config, nick=trigger.nick,
         channel=trigger.sender, time=pubdate)


### PR DESCRIPTION
```ValueError: time data '2011-07-06T06:26:28Z' does not match format '%Y-%m-%dT%H:%M:%S.%fZ' (file "/usr/lib/python3.6/_strptime.py", line 362, in _strptime)```

This has been happening very seldomly for a couple of weeks. I have seen the behaviour on my own bot as well as other Sopel bots on a variety of IRC servers.

A quick search found this issue: https://github.com/googleapis/google-api-dotnet-client/issues/1545