### PR TITLE
Add playlist link support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,14 @@ Copy the value it gives you into the prompt in the config wizard, or the
 
 The `api_key` option is self-explanatory (see above).
 
-By default, only the video length, uploader (channel name), view count, and
-upload date are shown. The included items, and the order in which they appear,
-depend on the `info_items` setting, which is a list of keywords. Unrecognized
-keywords are simply ignored. Supported `info_items` are:
+If video "watch" links contain a playlist ID, the plugin will show the
+playlist info as well as the video info by default. To disable this, set
+`playlist_watch` to `False`.
+
+For videos, by default, only the video length, uploader (channel name), view
+count, and upload date are shown. The included items, and the order in which
+they appear, depend on the `info_items` setting, which is a list of keywords.
+Unrecognized keywords are simply ignored. Supported `info_items` are:
 
 * `comments` (comment count)
 * `date` (upload time/date)

--- a/sopel_modules/youtube/youtube.py
+++ b/sopel_modules/youtube/youtube.py
@@ -236,6 +236,13 @@ def get_playlist_info(bot, trigger, match):
 
 
 def _say_playlist_result(bot, trigger, id_):
+    if not id_ or id_.upper() == 'WL':
+        # The playlist with ID of WL is valid only for an authenticated user.
+        # Someone probably linked a video they opened from their Watch Later,
+        # but we can't get any info about their queue. Silently ignore.
+        # Also silently ignore empty/falsy/None IDs, just in case.
+        return
+
     for n in range(num_retries + 1):
         try:
             result = bot.memory['youtube_api_client'].playlists().list(

--- a/sopel_modules/youtube/youtube.py
+++ b/sopel_modules/youtube/youtube.py
@@ -36,7 +36,7 @@ ISO8601_PERIOD_REGEX = re.compile(
     r"((?:T)(?P<h>[0-9]+([,.][0-9]+)?H)?"
     r"(?P<m>[0-9]+([,.][0-9]+)?M)?"
     r"(?P<s>[0-9]+([,.][0-9]+)?S)?)?$")
-regex = re.compile(r'(youtube\.com/watch\S*v=|youtu\.be/)([\w-]+)')
+video_regex = re.compile(r'(youtube\.com/watch\S*v=|youtu\.be/)([\w-]+)')
 num_retries = 5
 
 
@@ -79,7 +79,7 @@ def configure(config):
         "api_key", "Enter your Google API key.",
     )
     config.youtube.configure_setting(
-        "info_items", "Which attributes to show in response to links"
+        "info_items", "Which attributes to show in response to video links"
     )
 
 
@@ -108,7 +108,7 @@ def shutdown(bot):
 
 @commands('yt', 'youtube')
 @example('.yt how to be a nerdfighter FAQ')
-def search(bot, trigger):
+def video_search(bot, trigger):
     """Search YouTube"""
     if not trigger.group(2):
         return
@@ -134,17 +134,17 @@ def search(bot, trigger):
         bot.say("I couldn't find any YouTube videos for your query.")
         return
 
-    _say_result(bot, trigger, results[0]['id']['videoId'])
+    _say_video_result(bot, trigger, results[0]['id']['videoId'])
 
 
-@url(regex)
-def get_info(bot, trigger, match=None):
+@url(video_regex)
+def get_video_info(bot, trigger, match=None):
     """Get information about the linked YouTube video."""
     match = match or trigger
-    _say_result(bot, trigger, match.group(2), include_link=False)
+    _say_video_result(bot, trigger, match.group(2), include_link=False)
 
 
-def _say_result(bot, trigger, id_, include_link=True):
+def _say_video_result(bot, trigger, id_, include_link=True):
     for n in range(num_retries + 1):
         try:
             result = bot.memory['youtube_api_client'].videos().list(


### PR DESCRIPTION
Example output:

```irc
<dgw> https://www.youtube.com/playlist?list=PLMmqC65vzdRkFt8T0QSy8GuCYMV8nfodU
<SopelTest> [YouTube] Factorio 1.0 Gameplay | Playlist by ImKibitz | 3 items | Created Tuesday, August 18, 2020 13:46:27 (UTC)
```

I elected not to implement output customization for this because:

1. There aren't enough info items about playlists to really matter
2. I don't want to deal with the `info_items` config value not specifying that it's for videos, in any way (don't want to deal with renaming it either).