### PR TITLE
Use `BooleanAttribute` setting type (requires Sopel 7.1+)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sopel>=7.0,<8
+sopel>=7.1,<8
 google-api-python-client>=1.5.5,<1.8

--- a/sopel_modules/youtube/youtube.py
+++ b/sopel_modules/youtube/youtube.py
@@ -12,6 +12,7 @@ import googleapiclient.discovery
 import googleapiclient.errors
 
 from sopel.config.types import (
+    BooleanAttribute,
     ListAttribute,
     StaticSection,
     ValidatedAttribute,
@@ -93,7 +94,7 @@ class YoutubeSection(StaticSection):
     Available: uploader, date, length, views, comments, and votes_color or votes
     """
 
-    playlist_watch = ValidatedAttribute('playlist_watch', bool, default=True)
+    playlist_watch = BooleanAttribute('playlist_watch', default=True)
     """
     Whether to show playlist info if the list ID is embedded in a video watch link.
     """


### PR DESCRIPTION
The person responsible for implementing this new setting type (also me) probably should have set it up to accept the old `ValidatedAttribute` style _silently_ in 7.x, and start warning in 8.0, but oh well. Even if that's changed for an upcoming patch release of Sopel, this patch still needs to be written at some point.

Oh—fixes #40.