### PR TITLE
Use sopel.plugin instead of sopel.module

### DIFF
--- a/sopel_modules/youtube/youtube.py
+++ b/sopel_modules/youtube/youtube.py
@@ -18,7 +18,7 @@ from sopel.config.types import (
     NO_DEFAULT,
 )
 from sopel.formatting import color, colors
-from sopel.module import commands, example, url
+from sopel.plugin import commands, example, url
 import sopel.tools as tools
 import sopel.tools.time
 


### PR DESCRIPTION
`sopel.module         WARNING : Deprecated since 8.0, will be removed in 9.0: sopel.module has been replaced by sopel.plugin`
7.1.x-safe, since we already switched all the built-in plugins.