### PR TITLE
Catch more exceptions

### DIFF
--- a/sopel_modules/youtube/youtube.py
+++ b/sopel_modules/youtube/youtube.py
@@ -157,6 +157,13 @@ def video_search(bot, trigger):
                 return
             sleep(random() * 2**n)
             continue
+        except googleapiclient.errors.HttpError as e:
+            bot.say(_get_http_error_message(e))
+            return
+        except Exception as e:
+            # Catch-all, because enumerating all the possible exceptions is a waste of code lines
+            bot.say('Temporary error talking to YouTube: %s' % e)
+            return
         break
     results = results.get('items')
     if not results:
@@ -204,6 +211,10 @@ def _say_video_result(bot, trigger, id_, include_link=True):
             continue
         except googleapiclient.errors.HttpError as e:
             bot.say(_get_http_error_message(e))
+            return
+        except Exception as e:
+            # Catch-all, because enumerating all the possible exceptions is a waste of code lines
+            bot.say('Temporary error talking to YouTube: %s' % e)
             return
         break
     if not result:
@@ -321,6 +332,10 @@ def _say_playlist_result(bot, trigger, id_):
             continue
         except googleapiclient.errors.HttpError as e:
             bot.say(_get_http_error_message(e))
+            return
+        except Exception as e:
+            # Catch-all, because enumerating all the possible exceptions is a waste of code lines
+            bot.say('Temporary error talking to YouTube: %s' % e)
             return
         break
     if not result:


### PR DESCRIPTION
The timeout reported in #43 wasn't the cause of anything, but it _is_ ugly to see "Unexpected error". Might as well just catch exceptions thrown when talking to the API and present them in a _slightly_ friendlier way.

Debating whether this plugin needs a logger instance. I don't see a huge need for it, but might change that opinion later.