### PR TITLE
Stop trying to fetch/process dislike count

### DIFF
--- a/sopel_modules/youtube/youtube.py
+++ b/sopel_modules/youtube/youtube.py
@@ -198,7 +198,7 @@ def _say_video_result(bot, trigger, id_, include_link=True):
                             'actualStartTime,concurrentViewers,scheduledStartTime'
                         '),'
                         'statistics('
-                            'viewCount,commentCount,likeCount,dislikeCount'
+                            'viewCount,commentCount,likeCount'
                         ')'
                     ')',
             ).execute().get('items')
@@ -277,16 +277,10 @@ def _say_video_result(bot, trigger, id_, include_link=True):
             if "likeCount" in statistics:
                 likes = int(statistics["likeCount"])
                 message += " | " + color("{:,}+".format(likes), colors.GREEN)
-            if "dislikeCount" in statistics:
-                dislikes = int(statistics["dislikeCount"])
-                message += " | " + color("{:,}-".format(dislikes), colors.RED)
         elif item == "votes":
             if "likeCount" in statistics:
                 likes = int(statistics["likeCount"])
                 message += " | {:,}+".format(likes)
-            if "dislikeCount" in statistics:
-                dislikes = int(statistics["dislikeCount"])
-                message += " | {:,}-".format(dislikes)
 
     if include_link:
         message = message + ' | Link: https://youtu.be/' + id_


### PR DESCRIPTION
The YouTube API officially stopped returning public dislike info as of today, 13 December 2021.

It's possible to apply for an exemption and continue to receive dislike data on unauthenticated API calls, but only on the condition that said data is not displayed to end-users. Since showing info to end-users is the whole point of this plugin, we won't bother asking.

https://support.google.com/youtube/thread/134791097/update-to-youtube-dislike-counts