### PR TITLE
Deprecate `votes`/`votes_color` in favor of new `likes` info item

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Unrecognized keywords are simply ignored. Supported `info_items` are:
 * `comments` (comment count)
 * `date` (upload time/date)
 * `length` (duration)
+* `likes` (count)
 * `uploader` (channel name)
 * `views` (view count)
-* `votes_color` or `votes` (likes/dislikes, with or without IRC formatting)
+
+### Legacy `info_items`
+Prior to YouTube's removal of public dislike counts, there were two vote-related
+`info_items`: `votes` and `votes_color`. These keywords are deprecated as of
+`sopel-youtube` 0.4.3. They will function as aliases to the new `likes` keyword
+until they are removed entirely in v0.5 or thereabouts.

--- a/sopel_modules/youtube/youtube.py
+++ b/sopel_modules/youtube/youtube.py
@@ -273,14 +273,10 @@ def _say_video_result(bot, trigger, id_, include_link=True):
                 # live videos tend to have chats, not comments, so only show this
                 # if the video is not live-streaming
                 message += " | {:,} comments".format(int(statistics["commentCount"]))
-        elif item == "votes_color":
-            if "likeCount" in statistics:
-                likes = int(statistics["likeCount"])
-                message += " | " + color("{:,}+".format(likes), colors.GREEN)
-        elif item == "votes":
-            if "likeCount" in statistics:
-                likes = int(statistics["likeCount"])
-                message += " | {:,}+".format(likes)
+        elif item in ("likes", "votes_color", "votes") and "likeCount" in statistics:
+            # TODO: votes and votes_color died with the API's dislike count
+            # so remove them after some appropriate amount of time (v0.5.0-ish)
+            message += " | {:,} likes".format(int(statistics["likeCount"]))
 
     if include_link:
         message = message + ' | Link: https://youtu.be/' + id_


### PR DESCRIPTION
Tin. Resolves #46.