### PR TITLE
Format time using channel or bot's format

### DIFF
--- a/sopel_modules/youtube/youtube.py
+++ b/sopel_modules/youtube/youtube.py
@@ -367,10 +367,22 @@ def _parse_datetime(date):
 
 
 def _format_datetime(bot, trigger, date):
-    if type(date) != 'datetime':
+    if not isinstance(date, datetime):
         date = _parse_datetime(date)
-    return tools.time.format_time(bot.db, bot.config, nick=trigger.nick,
-        channel=trigger.sender, time=date)
+    # use channel or bot's timezone (not user)
+    zone = tools.time.get_timezone(
+        db=bot.db,
+        config=bot.config,
+        channel=trigger.sender,
+    )
+    # use channel or bot's time format (not user)
+    return tools.time.format_time(
+        bot.db,
+        bot.config,
+        zone,
+        channel=trigger.sender,
+        time=date,
+    )
 
 
 def _make_snippet_bidi_safe(snippet):


### PR DESCRIPTION
Following discussion about formatting time, this change the time format from:

    user > channel -> config

to:

    channel -> config

directly.

For good measure, it also uses the channel or config's timezone.

Oh, and also there was this weird `type(date) == 'datetime'` thing, I don't understand why, I just fixed it.