### PR TITLE
deps: allow newer versions of google-api where supported

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sopel>=7.1,<8
-google-api-python-client>=1.5.5,<1.8
+google-api-python-client>=1.5.5,<1.8; python_version < '3.6'
+google-api-python-client>=1.5.5,<3; python_version >= '3.6'


### PR DESCRIPTION
Support google-api-python-client 1.8-3 on python 3.6+

Fixes #34