### PR TITLE
build, init: move version number to setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sopel>=7.1,<8
 google-api-python-client>=1.5.5,<1.8; python_version < '3.6'
 google-api-python-client>=1.5.5,<3; python_version >= '3.6'
+setuptools  # any version should do; we just need pkg_resources at runtime

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 import os
 import sys
 from setuptools import setup, find_packages
-from sopel_modules.youtube import __version__
 
 
 if __name__ == '__main__':
@@ -29,7 +28,7 @@ with open('dev-requirements.txt') as dev_requirements_file:
 
 setup(
     name='sopel_modules.youtube',
-    version=__version__,
+    version='0.5.0',
     description='YouTube plugin for Sopel',
     long_description=readme + '\n\n' + history,
     long_description_content_type='text/markdown',

--- a/sopel_modules/youtube/__init__.py
+++ b/sopel_modules/youtube/__init__.py
@@ -5,14 +5,11 @@ YouTube plugin for Sopel
 """
 from __future__ import unicode_literals, absolute_import, division, print_function
 
-try:
-    from .youtube import *
-except ImportError:
-    # probably being imported by setup.py to get metadata before installation
-    # no cause for alarm
-    pass
+# replace with `importlib_metadata` when updating for Sopel 8.0
+import pkg_resources
+
+from .youtube import *
 
 __author__ = 'dgw'
 __email__ = 'dgw@technobabbl.es'
-__version__ = '0.5.0'
-
+__version__ = pkg_resources.get_distribution('sopel_modules.youtube').version


### PR DESCRIPTION
No longer try/catch and hide import errors. The plugin would appear to load if `googleapiclient` wasn't installed, but none of its handlers would be registered. This confused someone on IRC (and me, too, when I tried to help troubleshoot).

Not crazy about the runtime dependency on `pkg_resources` (meaning `setuptools` is needed *after* build/install), but this is what Sopel itself does in 7.x (8.x will move to `importlib_metadata`, as indicated by the relevant comment in this patch).

Doing this would have been the _correct_ fix for #9 as delivered in #13, but past-me was an idiot as usual.