### PR TITLE
Require Sopel 8.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,9 +18,8 @@ packages = find:
 zip_safe = false
 include_package_data = true
 install_requires =
-    sopel>=7.1,<9
-    google-api-python-client>=1.5.5,<1.8; python_version < '3.6'
-    google-api-python-client>=1.5.5,<3; python_version >= '3.6'
+    sopel>=8.0,<9
+    google-api-python-client>=1.5.5,<3
 
 [options.entry_points]
 sopel.plugins =

--- a/sopel_youtube/__init__.py
+++ b/sopel_youtube/__init__.py
@@ -1,9 +1,8 @@
-# coding=utf8
 """sopel-youtube
 
 YouTube link information plugin for Sopel.
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import annotations
 
 from datetime import datetime
 from random import random
@@ -13,7 +12,7 @@ from time import sleep
 
 import googleapiclient.discovery
 import googleapiclient.errors
-import httplib2
+import httplib2  # dependency of googleapiclient
 
 from sopel.config.types import (
     BooleanAttribute,
@@ -23,10 +22,7 @@ from sopel.config.types import (
     NO_DEFAULT,
 )
 from sopel.plugin import commands, example, url
-import sopel.tools as tools
-
-if sys.version_info.major < 3:
-    int = long
+from sopel import tools
 
 
 ISO8601_PERIOD_REGEX = re.compile(
@@ -117,6 +113,7 @@ def configure(config):
 
 def setup(bot):
     bot.config.define_section('youtube', YoutubeSection)
+
     if 'youtube_api_client' not in bot.memory:
         reason = None
         try:
@@ -144,6 +141,7 @@ def video_search(bot, trigger):
     """Search YouTube"""
     if not trigger.group(2):
         return
+
     for n in range(num_retries + 1):
         try:
             results = bot.memory['youtube_api_client'].search().list(
@@ -168,6 +166,7 @@ def video_search(bot, trigger):
             bot.say('Temporary error talking to YouTube: %s' % e)
             return
         break
+
     results = results.get('items')
     if not results:
         bot.say("I couldn't find any YouTube videos for your query.")
@@ -287,6 +286,7 @@ def _say_video_result(bot, trigger, id_, include_link=True):
 
     if include_link:
         message = message + ' | Link: https://youtu.be/' + id_
+
     bot.say(message)
 
 
@@ -339,10 +339,11 @@ def _say_playlist_result(bot, trigger, id_):
             bot.say('Temporary error talking to YouTube: %s' % e)
             return
         break
+
     if not result:
         return
-    result = result[0]
 
+    result = result[0]
     snippet = _make_snippet_bidi_safe(result['snippet'])
 
     # if owned by a known auto-playlist owner channel ID, say so, and skip


### PR DESCRIPTION
We're close to release upstream. There's no reason for the next release of this plugin to support Sopel 7 any more.

Dropping the old bot means we can also drop Python 2 and close #64.

Follow-up to this could include converting the package metadata to `pyproject.toml`, since newer version of `pip` complain if you're still using `setup.py` or `setup.cfg` metadata. I just didn't feel like opening that can of worms yet/tonight.