### PR TITLE
Remove deprecated `votes`-related `info_items`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,3 @@ Unrecognized keywords are simply ignored. Supported `info_items` are:
 * `likes` (count)
 * `uploader` (channel name)
 * `views` (view count)
-
-### Legacy `info_items`
-Prior to YouTube's removal of public dislike counts, there were two vote-related
-`info_items`: `votes` and `votes_color`. These keywords are deprecated as of
-`sopel-youtube` 0.4.3. They will function as aliases to the new `likes` keyword
-until they are removed entirely in v0.5 or thereabouts.

--- a/sopel_youtube/__init__.py
+++ b/sopel_youtube/__init__.py
@@ -280,9 +280,7 @@ def _say_video_result(bot, trigger, id_, include_link=True):
                 # live videos tend to have chats, not comments, so only show this
                 # if the video is not live-streaming
                 message += " | {:,} comments".format(int(statistics["commentCount"]))
-        elif item in ("likes", "votes_color", "votes") and "likeCount" in statistics:
-            # TODO: votes and votes_color died with the API's dislike count
-            # so remove them after some appropriate amount of time (v0.6.0-ish)
+        elif item == "likes" and "likeCount" in statistics:
             message += " | {:,} likes".format(int(statistics["likeCount"]))
 
     if include_link:


### PR DESCRIPTION
These were supposed to go away around 0.5.0-ish, oops.